### PR TITLE
Adding a default, empty sofe configuration.

### DIFF
--- a/src/sofe.js
+++ b/src/sofe.js
@@ -2,7 +2,7 @@ import { getServiceName, resolvePathFromService } from './utils.js';
 import { getUrlFromRegistry } from './registries.js';
 import { getManifest, clearManifest } from './manifest.js';
 
-const config = System.sofe;
+const config = System.sofe || {};
 
 const systemNormalize = System.normalize;
 const hasWindow = typeof window !== 'undefined';


### PR DESCRIPTION
The background for this change is that when jspm is building code, it is running
in an environment where System.sofe might not be defined. The example of this is
a sofe service that is using `jspm build` to bundle itself. The service itself hasn't
set up sofe, but rather is just wanting to produce a distributable.