### PR TITLE
Changing external getManifest to only return the exact manifest requested.

### DIFF
--- a/docs/sofe-api.md
+++ b/docs/sofe-api.md
@@ -154,8 +154,7 @@ if (isOverride('lodash')) {
 
 #### getManifest(url): Promise
 Returns a promise that will resolve with a flat object of key value pairs, where the keys are service names and the values are urls. If the manifest at the specified url has a chained `manifestUrl`, then
-the entire chain of manifests will be traversed, with the resulting manifest remaining a flat map of services. If two manifests have the same service, normal precedence rules will apply to determine
-which manifest will take precedence (whichever is retrieved first takes precedence).
+the chained manifests will be *not* be merged in or returned in any way.
 
 ```javascript
 import { getManifest } from 'sofe';

--- a/src/sofe.js
+++ b/src/sofe.js
@@ -21,5 +21,15 @@ export function getManifest(url) {
 		throw new Error(`sofe getManifest API must be called with a url string`);
 	}
 
-	return _getManifest({manifestUrl: url});
+	return new Promise((resolve, reject) => {
+		_getManifest({manifestUrl: url})
+		.then(() => {
+			getAllManifests()
+			.then(manifests => {
+				resolve(manifests.all[url].manifest)
+			})
+			.catch(reject);
+		})
+		.catch(reject);
+	});
 }

--- a/src/sofe.js
+++ b/src/sofe.js
@@ -22,8 +22,13 @@ export function getManifest(url) {
 	}
 
 	return new Promise((resolve, reject) => {
+		// Ensure that the manifest for this url has been retrieved
 		_getManifest({manifestUrl: url})
 		.then(() => {
+			/* We don't want the merged combination of all of the chained manifests,
+			 * which is what _getManifest returns. Instead, we want *just* the manifest
+			 * exactly as it is found at the specified url.
+			 */
 			getAllManifests()
 			.then(manifests => {
 				resolve(manifests.all[url].manifest)


### PR DESCRIPTION
This is important for canopy-sofe-extensions because we specifically want the exact manifest found at `thing`, `thanos`, `groot`, etc. We don't want a manifest that follows the whole chain of manifests and merges things together.