### PR TITLE
Relative paths

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "dist/sofe.js",
   "scripts": {
     "test": "karma start",
-    "build": "npm run clean && babel src --out-dir lib && node build.js && cp lib/blank.js dist/blank.js && uglifyjs dist/sofe.js --source-map dist/sofe.min.js.map -o dist/sofe.min.js",
+    "build": "npm run clean && babel src --out-dir lib && node build.js && cp lib/blank.js dist/blank.js && uglifyjs dist/sofe.js --source-map dist/sofe.min.js.map -o dist/sofe.min.js -m",
     "rollup": "rollup src/index.js -f cjs -o dist/sofe.js",
     "clean": "rm -rf lib",
     "prepublish": "npm run build",

--- a/src/hooks.js
+++ b/src/hooks.js
@@ -1,4 +1,4 @@
-import { getServiceName, resolvePathFromService } from './utils.js';
+import { getServiceName, resolvePathFromService, getUrlFromService } from './utils.js';
 import { getUrlFromRegistry } from './registries.js';
 import { getManifest, clearManifest } from './manifest.js';
 import { stepMiddleware } from './middleware.js';
@@ -71,6 +71,9 @@ export function locate(load) {
 	return new Promise((resolvePromise, reject) => {
 		stepMiddleware(allMiddleware, load, function(load, newMiddleware) {
 			function resolve(url) {
+				// Resolve relative paths
+				url = getUrlFromService(load.address, url);
+
 				stepMiddleware(newMiddleware, url, function(newUrl, newMiddleware) {
 					middlewareMap[id] = newMiddleware;
 					middlewareTracker = id;

--- a/src/utils.js
+++ b/src/utils.js
@@ -16,10 +16,14 @@ export function getServiceName(obj) {
 		throw new Error(`getServiceName must be called with a string url or with a SystemJS load object that has an address`);
 	}
 
+	// The service name might have a path in it!
+	// For example, you might `import a from 'service/a/path.js!sofe';`
+	// In that case, we want `getServiceName` to return just `'sesrvice'`;
 	let urlParts = getRegex().exec(address);
-
 	const splits = urlParts[5].split('/');
 
+	// There might be a leading `/`, if so `splits[0]` is empty and
+	// we want to get the second element of the array.
 	return splits[0] || splits[1];
 }
 
@@ -56,8 +60,14 @@ export function resolvePathFromService(services, name, parentName) {
  */
 export function getUrlFromService(service, url) {
 	let parts = getRegex().exec(service)[5].split('/');
+
+	// if there is a leading `/` then `parts[0]` will be empty
+	// and we want to strip that out.
 	parts = !parts[0] ? parts.slice(1) : parts;
 
+	// Remove the first element in the path, which should be the service name
+	// For example, you might `import a from 'service/a/path.js!sofe';`
+	// In that case, we want to remove `service` from the path;
 	const path = parts.slice(1).join('/');
 
 	if (path) {

--- a/src/utils.js
+++ b/src/utils.js
@@ -15,9 +15,12 @@ export function getServiceName(obj) {
 	} else {
 		throw new Error(`getServiceName must be called with a string url or with a SystemJS load object that has an address`);
 	}
-	const splits = address.split('/');
 
-	return splits[splits.length - 1];
+	let urlParts = getRegex().exec(address);
+
+	const splits = urlParts[5].split('/');
+
+	return splits[0] || splits[1];
 }
 
 /**
@@ -35,11 +38,33 @@ export function resolvePathFromService(services, name, parentName) {
 
 	let parentAddress = getServiceResolution(services, parentName);
 
-	let urlParts = (/^(([^:\/?#]+):)?(\/\/([^\/?#]*))?([^?#]*)(\?([^#]*))?(#(.*))?/g).exec(parentAddress);
+	let urlParts = getRegex().exec(parentAddress);
 
 	return urlParts[1] + urlParts[3] + join(
 		urlParts[5], '../', name
 	);
+}
+
+/**
+ * Given a resolved service url, generate a corresponding absolute path from the original service name.
+ * This is needed to resolve relative paths within the service name.
+ *
+ * @param {String} service The full service name requested to sofe, may include a relative path
+ * @param {String} url The resolved url of the service
+ *
+ * @return {String} A new url with. Possibly the same as the input url.
+ */
+export function getUrlFromService(service, url) {
+	let parts = getRegex().exec(service)[5].split('/');
+	parts = !parts[0] ? parts.slice(1) : parts;
+
+	const path = parts.slice(1).join('/');
+
+	if (path) {
+		return `${url.substring(0, url.lastIndexOf('/'))}/${path}`;
+	} else {
+		return url;
+	}
 }
 
 function getServiceResolution(services, name) {
@@ -48,4 +73,8 @@ function getServiceResolution(services, name) {
 			return services[service];
 		}
 	}
+}
+
+function getRegex() {
+	return /^(([^:\/?#]+):)?(\/\/([^\/?#]*))?([^?#]*)(\?([^#]*))?(#(.*))?/g;
 }

--- a/test/helper.test.js
+++ b/test/helper.test.js
@@ -1,8 +1,8 @@
-var root = 'http://localhost:' + window.location.port + '/base';
+let root = 'http://localhost:' + window.location.port + '/base';
 
 describe('helpers', function() {
 
-	var system;
+	let system;
 
 	beforeEach(function() {
 		system = new System.constructor();

--- a/test/sofe.test.js
+++ b/test/sofe.test.js
@@ -1,7 +1,7 @@
 describe('sofe api', () => {
-	var validManifestUrl = 'http://localhost:' + window.location.port + '/base/test/manifests/simple.json';
+	let validManifestUrl = 'http://localhost:' + window.location.port + '/base/test/manifests/simple.json';
 
-	var system;
+	let system;
 
 	beforeEach(function() {
 		system = new System.constructor();
@@ -84,11 +84,135 @@ describe('sofe api', () => {
 			system
 			.import('/base/src/sofe.js')
 			.then(function(sofe) {
-				var load = {
+				let load = {
 					address: "https://localhost:8083/service-name",
 					meta: {}
 				};
 				expect(sofe.getServiceName(load)).toEqual('service-name');
+				done();
+			})
+			.catch(fail);
+		});
+
+		it('parses service name from a relative path with ports', function(done) {
+			system
+			.import('/base/src/sofe.js')
+			.then(function(sofe) {
+				let load = {
+					address: "https://localhost:8083/service-name/relative.js",
+					meta: {}
+				};
+				expect(sofe.getServiceName(load)).toEqual('service-name');
+				done();
+			})
+			.catch(fail);
+		});
+
+		it('parses service name from a relative path', function(done) {
+			system
+			.import('/base/src/sofe.js')
+			.then(function(sofe) {
+				let load = {
+					address: "https://localhost/service-name/relative.js",
+					meta: {}
+				};
+				expect(sofe.getServiceName(load)).toEqual('service-name');
+				done();
+			})
+			.catch(fail);
+		});
+
+		it('parses service name from a relative path with dot', function(done) {
+			system
+			.import('/base/src/sofe.js')
+			.then(function(sofe) {
+				let load = {
+					address: "https://localhost/service-name.css/relative.js",
+					meta: {}
+				};
+				expect(sofe.getServiceName(load)).toEqual('service-name.css');
+				done();
+			})
+			.catch(fail);
+		});
+
+		it('parses service name with query params', function(done) {
+			system
+			.import('/base/src/sofe.js')
+			.then(function(sofe) {
+				let load = {
+					address: "https://localhost/service-name/relative.js?something=wow",
+					meta: {}
+				};
+				expect(sofe.getServiceName(load)).toEqual('service-name');
+				done();
+			})
+			.catch(fail);
+		});
+
+		it('parses service name with hash', function(done) {
+			system
+			.import('/base/src/sofe.js')
+			.then(function(sofe) {
+				let load = {
+					address: "https://localhost/service-name/relative.js#/something",
+					meta: {}
+				};
+				expect(sofe.getServiceName(load)).toEqual('service-name');
+				done();
+			})
+			.catch(fail);
+		});
+	});
+
+	describe('Relative service', function() {
+		it('resolve a service with no path', function(done) {
+			system
+			.import('/base/src/utils.js')
+			.then(function(utils) {
+				expect(
+					utils.getUrlFromService('https://localhost/someService', 'http://hi.com/someService.js')
+				).toBe('http://hi.com/someService.js')
+
+				done();
+			})
+			.catch(fail);
+		});
+
+		it('resolve a service a path', function(done) {
+			system
+			.import('/base/src/utils.js')
+			.then(function(utils) {
+				expect(
+					utils.getUrlFromService('https://localhost/someService/tester.js', 'http://hi.com/someService.js')
+				).toBe('http://hi.com/tester.js')
+
+				done();
+			})
+			.catch(fail);
+		});
+
+		it('resolve a service a path with directories', function(done) {
+			system
+			.import('/base/src/utils.js')
+			.then(function(utils) {
+				expect(
+					utils.getUrlFromService('https://localhost/someService/dir1/dir2/tester.js', 'http://hi.com/someService.js')
+				).toBe('http://hi.com/dir1/dir2/tester.js')
+
+				done();
+			})
+			.catch(fail);
+		});
+
+		it('resolve a service a path with directories on both', function(done) {
+			system
+			.import('/base/src/utils.js')
+			.then(function(utils) {
+				expect(
+					utils.getUrlFromService('https://localhost/someService/dir1/dir2/tester.js', 'http://hi.com/dir3/someService.js')
+				).toBe('http://hi.com/dir3/dir1/dir2/tester.js')
+
 				done();
 			})
 			.catch(fail);

--- a/test/static.test.js
+++ b/test/static.test.js
@@ -1,8 +1,8 @@
-var root = 'http://localhost:' + window.location.port + '/base';
+let root = 'http://localhost:' + window.location.port + '/base';
 
 describe('static resolution', function() {
 
-	var system;
+	let system;
 
 	beforeEach(function() {
 		system = new System.constructor();
@@ -83,6 +83,38 @@ describe('static resolution', function() {
 			});
 	});
 
+	it('should resolve relative services', function(run) {
+		system.config({
+			sofe: {
+				manifest: {
+					simple: root + '/test/services/simple1.js'
+				}
+			}
+		});
+
+		system.import('simple/simple2.js!/base/src/sofe.js')
+			.then(function(simple) {
+				expect(simple()).toBe('kwayis');
+				run();
+			});
+	});
+
+	it('should resolve relative services in sub-directories', function(run) {
+		system.config({
+			sofe: {
+				manifest: {
+					simple: root + '/simple1.js'
+				}
+			}
+		});
+
+		system.import('simple/test/services/simple2.js!/base/src/sofe.js')
+			.then(function(simple) {
+				expect(simple()).toBe('kwayis');
+				run();
+			});
+	});
+
 	it('should resolve relative dependencies inside services', function(run) {
 		system.config({
 			sofe: {
@@ -128,4 +160,5 @@ describe('static resolution', function() {
 				run();
 			});
 	});
+
 });


### PR DESCRIPTION
This adds the ability to import paths relative to a service location. For example, if `service-a` is located at `http://localhost/services/service-a/index.js` you can do the following:

```javascript
import dependency from 'service-a/dependency.js!sofe';
```

When `dependency.js` exists within the same directory as `index.js`. `dependency.js` could also exist in a sub directory, but *not* a parent directory.