### PR TITLE
I've found the logging for overrides to be a nuisance sometimes, especially when using sofe-inspector

### DIFF
--- a/build.js
+++ b/build.js
@@ -1,6 +1,8 @@
 var rollup = require('rollup').rollup;
-var npm = require('rollup-plugin-npm');
+var npm = require('rollup-plugin-node-resolve');
 var commonjs = require('rollup-plugin-commonjs');
+
+console.log("Creating rollup bundle")
 
 rollup({
 	entry: './lib/sofe.js',
@@ -23,4 +25,10 @@ rollup({
 	]
 }).then( function(bundle) {
 	bundle.write({ dest: 'dist/sofe.js', format: 'cjs' })
+	console.log("Wrote rollup bundle into dist")
+})
+.catch(function(err) {
+	setTimeout(function() {
+		throw err;
+	});
 });

--- a/package.json
+++ b/package.json
@@ -5,9 +5,9 @@
   "main": "dist/sofe.js",
   "scripts": {
     "test": "karma start",
-    "build": "npm run clean && babel src --out-dir lib && node build.js && cp lib/blank.js dist/blank.js && uglifyjs dist/sofe.js --source-map dist/sofe.min.js.map -o dist/sofe.min.js",
+    "build": "npm run clean && babel src --out-dir lib && node build.js && cp lib/blank.js dist/blank.js && uglifyjs dist/sofe.js --source-map dist/sofe.min.js.map -o dist/sofe.min.js && echo 'Uglified sofe into dist/sofe.min.js'",
     "rollup": "rollup src/index.js -f cjs -o dist/sofe.js",
-    "clean": "rm -rf lib",
+    "clean": "rm -rf lib dist",
     "prepublish": "npm run build",
     "examples": "cd examples/static && npm install && jspm install && cd ../remote && npm install && jspm install && cd ../../ && static -p5554 examples/"
   },
@@ -47,9 +47,9 @@
     "karma-phantomjs-launcher": "^0.2.1",
     "node-static": "^0.7.7",
     "phantomjs": "^1.9.19",
-    "rollup": "0.21.2",
-    "rollup-plugin-commonjs": "1.4.0",
-    "rollup-plugin-npm": "1.1.0",
+    "rollup": "0.37.0",
+    "rollup-plugin-commonjs": "6.0.0",
+    "rollup-plugin-node-resolve": "2.0.0",
     "systemjs": "^0.19.29",
     "uglify-js": "^2.6.2"
   },

--- a/package.json
+++ b/package.json
@@ -5,11 +5,7 @@
   "main": "dist/sofe.js",
   "scripts": {
     "test": "karma start",
-<<<<<<< HEAD
     "build": "npm run clean && babel src --out-dir lib && node build.js && cp lib/blank.js dist/blank.js && uglifyjs dist/sofe.js --source-map dist/sofe.min.js.map -o dist/sofe.min.js && echo 'Uglified sofe into dist/sofe.min.js'",
-=======
-    "build": "npm run clean && babel src --out-dir lib && node build.js && cp lib/blank.js dist/blank.js && uglifyjs dist/sofe.js --source-map dist/sofe.min.js.map -o dist/sofe.min.js -m && cp dist/sofe.min.js dist/sofe.js",
->>>>>>> origin/master
     "rollup": "rollup src/index.js -f cjs -o dist/sofe.js",
     "clean": "rm -rf lib dist",
     "prepublish": "npm run build",

--- a/src/hooks.js
+++ b/src/hooks.js
@@ -82,8 +82,6 @@ export function locate(load) {
 
 			//first check session storage (since it is very transient)
 			if (hasWindow && window.sessionStorage && window.sessionStorage.getItem(`sofe:${service}`)) {
-				console.log(`Using session storage override to resolve sofe service '${service}' to url '${window.sessionStorage.getItem(`sofe:${service}`)}'`);
-				console.log(`Run window.sessionStorage.removeItem('sofe:${service}') to remove this override`);
 				const url = window.sessionStorage.getItem(`sofe:${service}`);
 				serviceMap[load.name] = url;
 				addServiceOverride(service);
@@ -91,8 +89,6 @@ export function locate(load) {
 			}
 			//otherwise check local storage (since it is less transient)
 			else if (hasWindow && window.localStorage && window.localStorage.getItem(`sofe:${service}`)) {
-				console.log(`Using local storage override to resolve sofe service '${service}' to url '${window.localStorage.getItem(`sofe:${service}`)}'`);
-				console.log(`Run window.localStorage.removeItem('sofe:${service}') to remove this override`);
 				const url = window.localStorage.getItem(`sofe:${service}`);
 				serviceMap[load.name] = url;
 				addServiceOverride(service);

--- a/src/sofe.js
+++ b/src/sofe.js
@@ -38,3 +38,35 @@ export function getManifest(url) {
 		.catch(reject);
 	});
 }
+
+if (localStorage && !localStorage.getItem('disable-sofe-override-warning')) {
+	let numOverrides = 0;
+	for (let i=0; i<localStorage.length; i++) {
+		const key = localStorage.key(i);
+		const serviceName = key.slice('sofe:'.length);
+
+		if (key.match(/sofe:(\S)+/g)) {
+			console.info(`There is a local storage sofe override for the service '${serviceName}' to url '${localStorage.getItem(key)}'`);
+			numOverrides++;
+		}
+	}
+	if (numOverrides > 0) {
+		console.info(`Run localStorage.setItem('disable-sofe-override-warning', true) to turn off sofe override warnings`);
+	}
+}
+
+if (sessionStorage && !sessionStorage.getItem('disable-sofe-override-warning')) {
+	let numOverrides = 0;
+	for (let i=0; i<sessionStorage.length; i++) {
+		const key = sessionStorage.key(i);
+		const serviceName = key.slice('sofe:'.length);
+
+		if (key.match(/sofe:(\S)+/g)) {
+			console.info(`There is a session storage sofe override for the service '${serviceName}' to url '${sessionStorage.getItem(key)}'`);
+			numOverrides++;
+		}
+	}
+	if (numOverrides > 0) {
+		console.info(`Run sessionStorage.setItem('disable-sofe-override-warning', true) to turn off sofe override warnings`);
+	}
+}

--- a/src/sofe.js
+++ b/src/sofe.js
@@ -39,7 +39,7 @@ export function getManifest(url) {
 	});
 }
 
-if (localStorage && !localStorage.getItem('disable-sofe-override-warning')) {
+if (typeof localStorage !== 'undefined' && !localStorage.getItem('disable-sofe-override-warning')) {
 	let numOverrides = 0;
 	for (let i=0; i<localStorage.length; i++) {
 		const key = localStorage.key(i);
@@ -55,7 +55,7 @@ if (localStorage && !localStorage.getItem('disable-sofe-override-warning')) {
 	}
 }
 
-if (sessionStorage && !sessionStorage.getItem('disable-sofe-override-warning')) {
+if (typeof sessionStorage !== 'undefined' && !sessionStorage.getItem('disable-sofe-override-warning')) {
 	let numOverrides = 0;
 	for (let i=0; i<sessionStorage.length; i++) {
 		const key = sessionStorage.key(i);


### PR DESCRIPTION
- I think we should encourage usage of the sofe-inspector to know if there are overrides.
- Since this gets logged every time that `SystemJS.locate()` is called, it can get logged for the same service many times
- When hot reloading sofe services, this gets logged every time, which can become a nuisance

Here's why it's a nuisance sometimes:

![screen shot 2016-12-20 at 10 35 22 am](https://cloud.githubusercontent.com/assets/5524384/21361173/1c1b48c2-c6a0-11e6-844a-84dc8f9d1ed5.png)
